### PR TITLE
Fixed small issue in MultitextureRecord

### DIFF
--- a/openFlight/AncillaryRecords/MultiTextureRecord.cpp
+++ b/openFlight/AncillaryRecords/MultiTextureRecord.cpp
@@ -11,10 +11,11 @@ MultiTextureRecord::MultiTextureRecord(PrimaryRecord* ipParent) :
 AncillaryRecord(ipParent),
 mAttributeMask(0)
 {
-    memset(&mTexturePatternIndices[0], 0, 7*sizeof(uint16_t));
-    memset(&mMappingIndices[0], 0, 7*sizeof(uint16_t));
-    memset(&mEffects[0], 0, 7*sizeof(uint16_t));
-    memset(&mData[0], 0, 7*sizeof(uint16_t));
+    // -1 will become 65535 because storage is uint16_t
+    memset(&mTexturePatternIndices[0], -1, 7*sizeof(uint16_t));
+    memset(&mMappingIndices[0], -1, 7*sizeof(uint16_t));
+    memset(&mEffects[0], -1, 7*sizeof(uint16_t));
+    memset(&mData[0], -1, 7*sizeof(uint16_t));
 }
 
 //-------------------------------------------------------------------------
@@ -29,6 +30,7 @@ int MultiTextureRecord::getData(int iLayerIndex) const
     if(iLayerIndex >= 0 && iLayerIndex < 7)
     {
         r = mData[iLayerIndex];
+        if(r == 65535){r = -1;}
     }
     return r;
 }
@@ -65,6 +67,7 @@ int MultiTextureRecord::getMappingIndex(int iLayerIndex) const
     if(iLayerIndex >= 0 && iLayerIndex < 7)
     {
         r = mMappingIndices[iLayerIndex];
+        if(r == 65535){r = -1;}
     }
     return r;
 }
@@ -76,6 +79,7 @@ int MultiTextureRecord::getTexturePatternIndex(int iLayerIndex) const
     if(iLayerIndex >= 0 && iLayerIndex < 7)
     {
         r = mTexturePatternIndices[iLayerIndex];
+        if(r == 65535){r = -1;}
     }
     return r;
 }

--- a/unitTests/main.cpp
+++ b/unitTests/main.cpp
@@ -126,10 +126,10 @@ void testMultiTextureRecord()
         CHECK_TRUE( pMulti->getMappingIndex(0) == 3);
         CHECK_TRUE( pMulti->getData(0) == 4);
 
-        CHECK_TRUE( pMulti->getTexturePatternIndex(1) == 0);
-        CHECK_TRUE( pMulti->getEffect(1) == 0);
-        CHECK_TRUE( pMulti->getMappingIndex(1) == 0);
-        CHECK_TRUE( pMulti->getData(1) == 0);
+        CHECK_TRUE( pMulti->getTexturePatternIndex(1) == -1);
+        CHECK_TRUE( pMulti->getEffect(1) == OpenFlight::MultiTextureRecord::etUserDefined);
+        CHECK_TRUE( pMulti->getMappingIndex(1) == -1);
+        CHECK_TRUE( pMulti->getData(1) == -1);
 
         CHECK_TRUE( pMulti->getTexturePatternIndex(2) == 5);
         CHECK_TRUE( pMulti->getEffect(2) == OpenFlight::MultiTextureRecord::etBump);


### PR DESCRIPTION
- values are stored as uint16_t.
- invalid value from creator is -1 (65535), the api returns -1 in case of
  invalid value.